### PR TITLE
Add base config

### DIFF
--- a/client-client/vite.config.ts
+++ b/client-client/vite.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/mpc-hello/',
+  base: process.env.VITE_MPC_HELLO_BASE ?? '/mpc-hello/',
   plugins: [],
 });


### PR DESCRIPTION
## What is this PR doing?

Adds `VITE_MPC_HELLO_BASE` for specifying the base url when building with vite.

## How can these changes be manually tested?

```sh
VITE_MPC_HELLO_BASE="/foo/" npm run build
```

Inspect `dist/index.html` and check that urls for scripts etc begin with `/foo/`.

## Does this PR resolve or contribute to any issues?

Contributes to https://www.notion.so/pse-team/Move-gh-pages-apps-to-mpc-pse-dev-apps-1b6d57e8dd7e80b99a35c48324291920?pvs=4

## Checklist

- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines

- If your PR is not ready, mark it as a draft
