### PR TITLE
chore: naming convention

### DIFF
--- a/trinity/package-lock.json
+++ b/trinity/package-lock.json
@@ -1,14 +1,14 @@
 {
-  "name": "mpc-hello-next-js",
+  "name": "mpc-hello-trinity",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mpc-hello-next-js",
+      "name": "mpc-hello-trinity",
       "version": "0.0.0",
       "dependencies": {
-        "@trinity_2pc/core": "^0.1.0",
+        "@trinity-2pc/core": "^0.1.0",
         "emp-wasm-backend": "^0.3.1",
         "events": "^3.3.0",
         "mpc-framework": "^0.1.4",
@@ -786,10 +786,10 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@trinity_2pc/core": {
+    "node_modules/@trinity-2pc/core": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@trinity_2pc/core/-/core-0.1.0.tgz",
-      "integrity": "sha512-fwPFvyoWV5+xLblgbnxf7W13zIwoAzPzeOyAYRbZPJwwvRhBknGTcusI0ai1rV5uwzSkz8lGPK/xe+AsRqSc3w=="
+      "resolved": "https://registry.npmjs.org/@trinity-2pc/core/-/core-0.1.0.tgz",
+      "integrity": "sha512-5TLdX8rzzUaQ2QBuP4yTxu3iGzHM/EI+MO0DB9Cufo5jcOEVHJRHwWaVVra1Bu2RjNUVDXA/okcef0lDFKu9ow=="
     },
     "node_modules/@types/aes-js": {
       "version": "3.1.4",

--- a/trinity/package.json
+++ b/trinity/package.json
@@ -11,7 +11,7 @@
     "format:fix": "prettier -w ."
   },
   "dependencies": {
-    "@trinity_2pc/core": "^0.1.0",
+    "@trinity-2pc/core": "^0.1.0",
     "emp-wasm-backend": "^0.3.1",
     "events": "^3.3.0",
     "mpc-framework": "^0.1.4",

--- a/trinity/src/app/page.tsx
+++ b/trinity/src/app/page.tsx
@@ -18,7 +18,7 @@ import {
   TrinityModule,
   TrinityWasmSetup,
   intToUint8Array2,
-} from '@trinity_2pc/core';
+} from '@trinity-2pc/core';
 
 // Helper function to convert an integer to a Uint8Array
 function booleanArrayToInteger(boolArray: Uint8Array): number {

--- a/trinity/src/utils/generateProtocol.ts
+++ b/trinity/src/utils/generateProtocol.ts
@@ -1,6 +1,6 @@
 import * as summon from 'summon-ts';
 import getCircuitFiles from './getCircuitFiles';
-import { initTrinity, parse_circuit } from '@trinity_2pc/core';
+import { initTrinity, parseCircuit } from '@trinity-2pc/core';
 
 export default async function generateProtocol() {
   await summon.init();
@@ -12,7 +12,7 @@ export default async function generateProtocol() {
     await getCircuitFiles(),
   );
 
-  let circuit_parsed = parse_circuit(circuit.circuit.bristol, 16, 16, 16);
+  let circuit_parsed = parseCircuit(circuit.circuit.bristol, 16, 16, 16);
 
   return { trinityModule, circuit_parsed };
 }


### PR DESCRIPTION
## What is this PR doing?

This PR adopts the right convention for naming. Changed the name of the Trinity npm org and package.

The following methods will also adopt the naming convention, but they will be part of another refactor of Trinity:
- `from_bundle()`
- `to_sender_setup()`
- `from_sender_setup()`

## How can these changes be manually tested?
N/A

## Does this PR resolve or contribute to any issues?
No

## Checklist

- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines

- If your PR is not ready, mark it as a draft
